### PR TITLE
Allow zlib-wrapped gzip streams

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -38,7 +38,7 @@ function createBuffer(str, enc) {
 
 
 // Create gzip stream
-var gzip = new compress.Gzip(4);
+var gzip = new compress.Gzip(4, 16 + MAX_WBITS);
 sys.puts('gzip created');
 
 // Pump data to be compressed

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -275,3 +275,6 @@ exports.BzipStream = BzipStream;
 exports.BunzipStream = BunzipStream;
 
 exports.setApiWarnings = setApiWarnings;
+
+exports.MAX_WBITS = bindings.MAX_WBITS;
+exports.Z_DEFAULT_COMPRESSION = bindings.Z_DEFAULT_COMPRESSION;

--- a/src/compress.cc
+++ b/src/compress.cc
@@ -16,6 +16,8 @@ init (Handle<Object> target)
 #ifdef WITH_GZIP
   Gzip::Initialize(target);
   Gunzip::Initialize(target);
+	target->Set(v8::String::NewSymbol("MAX_WBITS"), v8::Integer::New(MAX_WBITS));
+	target->Set(v8::String::NewSymbol("Z_DEFAULT_COMPRESSION"), v8::Integer::New(Z_DEFAULT_COMPRESSION));
 #endif
 
 #ifdef WITH_BZIP

--- a/src/gzip.cc
+++ b/src/gzip.cc
@@ -103,6 +103,7 @@ class GzipImpl {
     HandleScope scope;
 
     int level = Z_DEFAULT_COMPRESSION;
+    int wbits = 16 + MAX_WBITS;
     if (args.Length() > 0 && !args[0]->IsUndefined()) {
       if (!args[0]->IsInt32()) {
         Local<Value> exception = Exception::TypeError(
@@ -112,12 +113,21 @@ class GzipImpl {
       level = args[0]->Int32Value();
     }
 
+    if (args.Length() > 1 && !args[1]->IsUndefined()) {
+      if (!args[1]->IsInt32()) {
+        Local<Value> exception = Exception::TypeError(
+            String::New("wbits must be an integer"));
+        return ThrowException(exception);
+      }
+      level = args[1]->Int32Value();
+    }
+
     stream_.zalloc = Z_NULL;
     stream_.zfree = Z_NULL;
     stream_.opaque = Z_NULL;
 
     int ret = deflateInit2(&stream_, level,
-                           Z_DEFLATED, 16 + MAX_WBITS, 8, Z_DEFAULT_STRATEGY);
+                           Z_DEFLATED, wbits, 8, Z_DEFAULT_STRATEGY);
     if (Utils::IsError(ret)) {
       return ThrowException(Utils::GetException(ret));
     }
@@ -182,7 +192,17 @@ class GunzipImpl {
     stream_.avail_in = 0;
     stream_.next_in = Z_NULL;
 
-    int ret = inflateInit2(&stream_, 16 + MAX_WBITS);
+    int wbits = 16 + MAX_WBITS;
+    if (args.Length() > 0 && !args[0]->IsUndefined()) {
+      if (!args[0]->IsInt32()) {
+        Local<Value> exception = Exception::TypeError(
+            String::New("wbits must be an integer"));
+        return ThrowException(exception);
+      }
+      wbits = args[0]->Int32Value();
+    }
+
+    int ret = inflateInit2(&stream_, wbits);
     if (Utils::IsError(ret)) {
       return ThrowException(Utils::GetException(ret));
     }

--- a/src/gzip.cc
+++ b/src/gzip.cc
@@ -119,7 +119,7 @@ class GzipImpl {
             String::New("wbits must be an integer"));
         return ThrowException(exception);
       }
-      level = args[1]->Int32Value();
+      wbits = args[1]->Int32Value();
     }
 
     stream_.zalloc = Z_NULL;


### PR DESCRIPTION
Heya,

I added an optional argument to the Gzip/Gunzip streams to allow the user to specify wbits as MAX_WBITS and thus write Zlib-wrapped streams, which is useful for a variety of network applications.
