### PR TITLE
Node v0.3.x support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
+.lock-wscript
 

--- a/src/zlib.h
+++ b/src/zlib.h
@@ -85,8 +85,8 @@ class ZipLib : ObjectWrap {
     Request(ZipLib *self, Local<Value> inputBuffer, Local<Function> callback)
       : kind_(RWrite), self_(self),
       buffer_(Persistent<Value>::New(inputBuffer)),
-      data_(GetBuffer(inputBuffer)->data()),
-      length_(GetBuffer(inputBuffer)->length()),
+      data_(Buffer::Data(inputBuffer->ToObject())),
+      length_(Buffer::Length(inputBuffer->ToObject())),
       callback_(Persistent<Function>::New(callback))
     {}
     
@@ -107,10 +107,6 @@ class ZipLib : ObjectWrap {
       if (!callback_.IsEmpty()) {
         callback_.Dispose();
       }
-    }
-
-    static Buffer *GetBuffer(Local<Value> buffer) {
-      return ObjectWrap::Unwrap<Buffer>(buffer->ToObject());
     }
 
    public:


### PR DESCRIPTION
This is a fix that also addresses [issue 9](https://github.com/egorich239/node-compress/issues#issue/9), but I can't create a pull request for that :)

I'm not sure how you'd like to deal with this since v0.3.x is considered unstable, but we at BrightTag would sure like to be able to test out v0.3.x stuff and use node-compress.

This change compiles against v0.3.1 and v0.3.3. I have not checked v0.3.4 yet.
